### PR TITLE
Add a local copy of the softfloat library

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,5 +49,3 @@ jobs:
       - name: Build
         run: cabal build pkg:softfloat-hs
 
-      - name: Test
-        run: cabal test pkg:softfloat-hs --test-show-details=direct

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,4 +50,4 @@ jobs:
         run: cabal build pkg:softfloat-hs
 
       - name: Test
-        run: cabal test pkg:softfloat-hs
+        run: cabal test pkg:softfloat-hs --test-show-details=direct

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,50 @@
+name: softfloat-hs CI
+on:
+  - push
+  - pull_request
+
+# The CACHE_VERSION can be updated to force the use of a new cache if
+# the current cache contents become corrupted/invalid.  This can
+# sometimes happen when (for example) the OS version is changed but
+# older .so files are cached, which can have various effects
+# (e.g. cabal complains it can't find a valid version of the "happy"
+# tool).
+env:
+  CACHE_VERSION: 1
+
+jobs:
+  linux:
+    name: Testing ${{ matrix.os }} GHC-${{ matrix.ghc }}
+    runs-on: ${{ matrix.os }}
+    continue-on-error: ${{ matrix.allow-failure }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+        ghc: [9.0, 8.10, 8.8, 8.6]
+        allow-failure: [false]
+      fail-fast: false
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: true
+      - uses: actions/cache@v2
+        name: Cache builds
+        with:
+          path: |
+            ${{ steps.setup-haskell.outputs.cabal-store }}
+            ~/.cabal/packages
+            ~/.cabal/store
+            dist-newstyle
+          key: |
+            ${{ env.CACHE_VERSION }}-cabal-${{ runner.os }}-ghc${{ matrix.ghc }}-${{ github.ref }}
+          restore-keys: |
+            ${{ env.CACHE_VERSION }}-cabal-${{ runner.os }}-ghc${{ matrix.ghc }}-
+
+      - uses: haskell/actions/setup@v1
+        id: setup-haskell-cabal
+        name: Setup Haskell
+        with:
+          ghc-version: ${{ matrix.ghc }}
+
+      - name: Build
+        run: cabal build pkg:softfloat-hs

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,3 +48,6 @@ jobs:
 
       - name: Build
         run: cabal build pkg:softfloat-hs
+
+      - name: Test
+        run: cabal test pkg:softfloat-hs

--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,7 @@ softfloat:
 	mkdir -p lib
 	gcc $(CFLAGS) -o lib/$(LIBNAME) $(SOFTFLOAT_PATH)/*.o
 
-testfloat:
+testfloat: softfloat
 	cd $(TESTFLOAT_PATH) &&	make all
 	ln -s ../$(TESTFLOAT_PATH)/testfloat lib/testfloat
 	ln -s ../$(TESTFLOAT_PATH)/testfloat_gen lib/testfloat_gen

--- a/softfloat-hs.cabal
+++ b/softfloat-hs.cabal
@@ -375,7 +375,8 @@ executable fpgen
                        directory,
                        process
 
-executable testfloat
+test-suite testfloat
+  type:                exitcode-stdio-1.0
   hs-source-dirs:      test
   main-is:             Testfloat.hs
   other-modules:       Ops

--- a/softfloat-hs.cabal
+++ b/softfloat-hs.cabal
@@ -15,6 +15,11 @@ build-type:          Simple
 cabal-version:       >=1.10
 extra-source-files:  README.md
 
+flag UseBundledC
+     description: Use a bundled copy of the C sources for the softfloat library
+     default: True
+     manual: True
+
 library
   exposed-modules:     SoftFloat
                      , SoftFloat.Internal
@@ -23,30 +28,362 @@ library
   install-includes:    softfloat_wrappers.h
   c-sources:           csrc/softfloat_wrappers.c
   ghc-options:         -Wall
-  extra-libraries:     softfloat1
   default-language:    Haskell2010
   build-depends:       base >= 4.7 && < 5
+  if flag(UseBundledC) && ( (os(linux) && arch(x86_64)) || (os(darwin) && arch(x86_64)) )
+    if (os(linux) || os(darwin)) && arch(x86_64)
+      cc-options: -DSOFTFLOAT_FAST_INT64 -O2 -DSOFTFLOAT_ROUND_ODD -DINLINE_LEVEL=5 -DSOFTFLOAT_FAST_DIV32TO16 -DSOFTFLOAT_FAST_DIV64TO32
+      include-dirs: berkeley-softfloat-3/build/Linux-x86_64-GCC
+                    berkeley-softfloat-3/source/8086-SSE
+                    berkeley-softfloat-3/source/include
 
--- executable fpgen
---   hs-source-dirs:      test
---   main-is:             Fpgen.hs
---   ghc-options:         -threaded -Wall
---   default-language:    Haskell2010
---   build-depends:       base,
---                        softfloat-hs,
---                        parsec,
---                        directory,
---                        process
+      c-sources:
+        berkeley-softfloat-3/source/8086-SSE/extF80M_isSignalingNaN.c
+        berkeley-softfloat-3/source/8086-SSE/f128M_isSignalingNaN.c
+        berkeley-softfloat-3/source/8086-SSE/s_commonNaNToExtF80M.c
+        berkeley-softfloat-3/source/8086-SSE/s_commonNaNToExtF80UI.c
+        berkeley-softfloat-3/source/8086-SSE/s_commonNaNToF16UI.c
+        berkeley-softfloat-3/source/8086-SSE/s_commonNaNToF32UI.c
+        berkeley-softfloat-3/source/8086-SSE/s_commonNaNToF64UI.c
+        berkeley-softfloat-3/source/8086-SSE/s_extF80MToCommonNaN.c
+        berkeley-softfloat-3/source/8086-SSE/s_extF80UIToCommonNaN.c
+        berkeley-softfloat-3/source/8086-SSE/s_f16UIToCommonNaN.c
+        berkeley-softfloat-3/source/8086-SSE/s_f32UIToCommonNaN.c
+        berkeley-softfloat-3/source/8086-SSE/s_f64UIToCommonNaN.c
+        berkeley-softfloat-3/source/8086-SSE/softfloat_raiseFlags.c
+        berkeley-softfloat-3/source/8086-SSE/s_propagateNaNExtF80M.c
+        berkeley-softfloat-3/source/8086-SSE/s_propagateNaNExtF80UI.c
+        berkeley-softfloat-3/source/8086-SSE/s_propagateNaNF16UI.c
+        berkeley-softfloat-3/source/8086-SSE/s_propagateNaNF32UI.c
+        berkeley-softfloat-3/source/8086-SSE/s_propagateNaNF64UI.c
 
--- executable testfloat
---   hs-source-dirs:      test
---   main-is:             Testfloat.hs
---   other-modules:       Ops
---   ghc-options:         -threaded -Wall
---   default-language:    Haskell2010
---   build-depends:       base,
---                        softfloat-hs,
---                        split,
---                        process,
---                        optparse-applicative,
---                        random
+    c-sources:
+      berkeley-softfloat-3/source/extF80M_add.c
+      berkeley-softfloat-3/source/extF80M_div.c
+      berkeley-softfloat-3/source/extF80M_eq.c
+      berkeley-softfloat-3/source/extF80M_eq_signaling.c
+      berkeley-softfloat-3/source/extF80M_le.c
+      berkeley-softfloat-3/source/extF80M_le_quiet.c
+      berkeley-softfloat-3/source/extF80M_lt.c
+      berkeley-softfloat-3/source/extF80M_lt_quiet.c
+      berkeley-softfloat-3/source/extF80M_mul.c
+      berkeley-softfloat-3/source/extF80M_rem.c
+      berkeley-softfloat-3/source/extF80M_roundToInt.c
+      berkeley-softfloat-3/source/extF80M_sqrt.c
+      berkeley-softfloat-3/source/extF80M_sub.c
+      berkeley-softfloat-3/source/extF80M_to_f128M.c
+      berkeley-softfloat-3/source/extF80M_to_f16.c
+      berkeley-softfloat-3/source/extF80M_to_f32.c
+      berkeley-softfloat-3/source/extF80M_to_f64.c
+      berkeley-softfloat-3/source/extF80M_to_i32.c
+      berkeley-softfloat-3/source/extF80M_to_i32_r_minMag.c
+      berkeley-softfloat-3/source/extF80M_to_i64.c
+      berkeley-softfloat-3/source/extF80M_to_i64_r_minMag.c
+      berkeley-softfloat-3/source/extF80M_to_ui32.c
+      berkeley-softfloat-3/source/extF80M_to_ui32_r_minMag.c
+      berkeley-softfloat-3/source/extF80M_to_ui64.c
+      berkeley-softfloat-3/source/extF80M_to_ui64_r_minMag.c
+      berkeley-softfloat-3/source/extF80_add.c
+      berkeley-softfloat-3/source/extF80_div.c
+      berkeley-softfloat-3/source/extF80_eq.c
+      berkeley-softfloat-3/source/extF80_eq_signaling.c
+      berkeley-softfloat-3/source/extF80_isSignalingNaN.c
+      berkeley-softfloat-3/source/extF80_le.c
+      berkeley-softfloat-3/source/extF80_le_quiet.c
+      berkeley-softfloat-3/source/extF80_lt.c
+      berkeley-softfloat-3/source/extF80_lt_quiet.c
+      berkeley-softfloat-3/source/extF80_mul.c
+      berkeley-softfloat-3/source/extF80_rem.c
+      berkeley-softfloat-3/source/extF80_roundToInt.c
+      berkeley-softfloat-3/source/extF80_sqrt.c
+      berkeley-softfloat-3/source/extF80_sub.c
+      berkeley-softfloat-3/source/extF80_to_f128.c
+      berkeley-softfloat-3/source/extF80_to_f16.c
+      berkeley-softfloat-3/source/extF80_to_f32.c
+      berkeley-softfloat-3/source/extF80_to_f64.c
+      berkeley-softfloat-3/source/extF80_to_i32.c
+      berkeley-softfloat-3/source/extF80_to_i32_r_minMag.c
+      berkeley-softfloat-3/source/extF80_to_i64.c
+      berkeley-softfloat-3/source/extF80_to_i64_r_minMag.c
+      berkeley-softfloat-3/source/extF80_to_ui32.c
+      berkeley-softfloat-3/source/extF80_to_ui32_r_minMag.c
+      berkeley-softfloat-3/source/extF80_to_ui64.c
+      berkeley-softfloat-3/source/extF80_to_ui64_r_minMag.c
+      berkeley-softfloat-3/source/f128M_add.c
+      berkeley-softfloat-3/source/f128M_div.c
+      berkeley-softfloat-3/source/f128M_eq.c
+      berkeley-softfloat-3/source/f128M_eq_signaling.c
+      berkeley-softfloat-3/source/f128M_le.c
+      berkeley-softfloat-3/source/f128M_le_quiet.c
+      berkeley-softfloat-3/source/f128M_lt.c
+      berkeley-softfloat-3/source/f128M_lt_quiet.c
+      berkeley-softfloat-3/source/f128M_mul.c
+      berkeley-softfloat-3/source/f128M_mulAdd.c
+      berkeley-softfloat-3/source/f128M_rem.c
+      berkeley-softfloat-3/source/f128M_roundToInt.c
+      berkeley-softfloat-3/source/f128M_sqrt.c
+      berkeley-softfloat-3/source/f128M_sub.c
+      berkeley-softfloat-3/source/f128M_to_extF80M.c
+      berkeley-softfloat-3/source/f128M_to_f16.c
+      berkeley-softfloat-3/source/f128M_to_f32.c
+      berkeley-softfloat-3/source/f128M_to_f64.c
+      berkeley-softfloat-3/source/f128M_to_i32.c
+      berkeley-softfloat-3/source/f128M_to_i32_r_minMag.c
+      berkeley-softfloat-3/source/f128M_to_i64.c
+      berkeley-softfloat-3/source/f128M_to_i64_r_minMag.c
+      berkeley-softfloat-3/source/f128M_to_ui32.c
+      berkeley-softfloat-3/source/f128M_to_ui32_r_minMag.c
+      berkeley-softfloat-3/source/f128M_to_ui64.c
+      berkeley-softfloat-3/source/f128M_to_ui64_r_minMag.c
+      berkeley-softfloat-3/source/f128_add.c
+      berkeley-softfloat-3/source/f128_div.c
+      berkeley-softfloat-3/source/f128_eq.c
+      berkeley-softfloat-3/source/f128_eq_signaling.c
+      berkeley-softfloat-3/source/f128_isSignalingNaN.c
+      berkeley-softfloat-3/source/f128_le.c
+      berkeley-softfloat-3/source/f128_le_quiet.c
+      berkeley-softfloat-3/source/f128_lt.c
+      berkeley-softfloat-3/source/f128_lt_quiet.c
+      berkeley-softfloat-3/source/f128_mul.c
+      berkeley-softfloat-3/source/f128_mulAdd.c
+      berkeley-softfloat-3/source/f128_rem.c
+      berkeley-softfloat-3/source/f128_roundToInt.c
+      berkeley-softfloat-3/source/f128_sqrt.c
+      berkeley-softfloat-3/source/f128_sub.c
+      berkeley-softfloat-3/source/f128_to_extF80.c
+      berkeley-softfloat-3/source/f128_to_f16.c
+      berkeley-softfloat-3/source/f128_to_f32.c
+      berkeley-softfloat-3/source/f128_to_f64.c
+      berkeley-softfloat-3/source/f128_to_i32.c
+      berkeley-softfloat-3/source/f128_to_i32_r_minMag.c
+      berkeley-softfloat-3/source/f128_to_i64.c
+      berkeley-softfloat-3/source/f128_to_i64_r_minMag.c
+      berkeley-softfloat-3/source/f128_to_ui32.c
+      berkeley-softfloat-3/source/f128_to_ui32_r_minMag.c
+      berkeley-softfloat-3/source/f128_to_ui64.c
+      berkeley-softfloat-3/source/f128_to_ui64_r_minMag.c
+      berkeley-softfloat-3/source/f16_add.c
+      berkeley-softfloat-3/source/f16_div.c
+      berkeley-softfloat-3/source/f16_eq.c
+      berkeley-softfloat-3/source/f16_eq_signaling.c
+      berkeley-softfloat-3/source/f16_isSignalingNaN.c
+      berkeley-softfloat-3/source/f16_le.c
+      berkeley-softfloat-3/source/f16_le_quiet.c
+      berkeley-softfloat-3/source/f16_lt.c
+      berkeley-softfloat-3/source/f16_lt_quiet.c
+      berkeley-softfloat-3/source/f16_mul.c
+      berkeley-softfloat-3/source/f16_mulAdd.c
+      berkeley-softfloat-3/source/f16_rem.c
+      berkeley-softfloat-3/source/f16_roundToInt.c
+      berkeley-softfloat-3/source/f16_sqrt.c
+      berkeley-softfloat-3/source/f16_sub.c
+      berkeley-softfloat-3/source/f16_to_extF80.c
+      berkeley-softfloat-3/source/f16_to_extF80M.c
+      berkeley-softfloat-3/source/f16_to_f128.c
+      berkeley-softfloat-3/source/f16_to_f128M.c
+      berkeley-softfloat-3/source/f16_to_f32.c
+      berkeley-softfloat-3/source/f16_to_f64.c
+      berkeley-softfloat-3/source/f16_to_i32.c
+      berkeley-softfloat-3/source/f16_to_i32_r_minMag.c
+      berkeley-softfloat-3/source/f16_to_i64.c
+      berkeley-softfloat-3/source/f16_to_i64_r_minMag.c
+      berkeley-softfloat-3/source/f16_to_ui32.c
+      berkeley-softfloat-3/source/f16_to_ui32_r_minMag.c
+      berkeley-softfloat-3/source/f16_to_ui64.c
+      berkeley-softfloat-3/source/f16_to_ui64_r_minMag.c
+      berkeley-softfloat-3/source/f32_add.c
+      berkeley-softfloat-3/source/f32_div.c
+      berkeley-softfloat-3/source/f32_eq.c
+      berkeley-softfloat-3/source/f32_eq_signaling.c
+      berkeley-softfloat-3/source/f32_isSignalingNaN.c
+      berkeley-softfloat-3/source/f32_le.c
+      berkeley-softfloat-3/source/f32_le_quiet.c
+      berkeley-softfloat-3/source/f32_lt.c
+      berkeley-softfloat-3/source/f32_lt_quiet.c
+      berkeley-softfloat-3/source/f32_mul.c
+      berkeley-softfloat-3/source/f32_mulAdd.c
+      berkeley-softfloat-3/source/f32_rem.c
+      berkeley-softfloat-3/source/f32_roundToInt.c
+      berkeley-softfloat-3/source/f32_sqrt.c
+      berkeley-softfloat-3/source/f32_sub.c
+      berkeley-softfloat-3/source/f32_to_extF80.c
+      berkeley-softfloat-3/source/f32_to_extF80M.c
+      berkeley-softfloat-3/source/f32_to_f128.c
+      berkeley-softfloat-3/source/f32_to_f128M.c
+      berkeley-softfloat-3/source/f32_to_f16.c
+      berkeley-softfloat-3/source/f32_to_f64.c
+      berkeley-softfloat-3/source/f32_to_i32.c
+      berkeley-softfloat-3/source/f32_to_i32_r_minMag.c
+      berkeley-softfloat-3/source/f32_to_i64.c
+      berkeley-softfloat-3/source/f32_to_i64_r_minMag.c
+      berkeley-softfloat-3/source/f32_to_ui32.c
+      berkeley-softfloat-3/source/f32_to_ui32_r_minMag.c
+      berkeley-softfloat-3/source/f32_to_ui64.c
+      berkeley-softfloat-3/source/f32_to_ui64_r_minMag.c
+      berkeley-softfloat-3/source/f64_add.c
+      berkeley-softfloat-3/source/f64_div.c
+      berkeley-softfloat-3/source/f64_eq.c
+      berkeley-softfloat-3/source/f64_eq_signaling.c
+      berkeley-softfloat-3/source/f64_isSignalingNaN.c
+      berkeley-softfloat-3/source/f64_le.c
+      berkeley-softfloat-3/source/f64_le_quiet.c
+      berkeley-softfloat-3/source/f64_lt.c
+      berkeley-softfloat-3/source/f64_lt_quiet.c
+      berkeley-softfloat-3/source/f64_mul.c
+      berkeley-softfloat-3/source/f64_mulAdd.c
+      berkeley-softfloat-3/source/f64_rem.c
+      berkeley-softfloat-3/source/f64_roundToInt.c
+      berkeley-softfloat-3/source/f64_sqrt.c
+      berkeley-softfloat-3/source/f64_sub.c
+      berkeley-softfloat-3/source/f64_to_extF80.c
+      berkeley-softfloat-3/source/f64_to_extF80M.c
+      berkeley-softfloat-3/source/f64_to_f128.c
+      berkeley-softfloat-3/source/f64_to_f128M.c
+      berkeley-softfloat-3/source/f64_to_f16.c
+      berkeley-softfloat-3/source/f64_to_f32.c
+      berkeley-softfloat-3/source/f64_to_i32.c
+      berkeley-softfloat-3/source/f64_to_i32_r_minMag.c
+      berkeley-softfloat-3/source/f64_to_i64.c
+      berkeley-softfloat-3/source/f64_to_i64_r_minMag.c
+      berkeley-softfloat-3/source/f64_to_ui32.c
+      berkeley-softfloat-3/source/f64_to_ui32_r_minMag.c
+      berkeley-softfloat-3/source/f64_to_ui64.c
+      berkeley-softfloat-3/source/f64_to_ui64_r_minMag.c
+      berkeley-softfloat-3/source/i32_to_extF80.c
+      berkeley-softfloat-3/source/i32_to_extF80M.c
+      berkeley-softfloat-3/source/i32_to_f128.c
+      berkeley-softfloat-3/source/i32_to_f128M.c
+      berkeley-softfloat-3/source/i32_to_f16.c
+      berkeley-softfloat-3/source/i32_to_f32.c
+      berkeley-softfloat-3/source/i32_to_f64.c
+      berkeley-softfloat-3/source/i64_to_extF80.c
+      berkeley-softfloat-3/source/i64_to_extF80M.c
+      berkeley-softfloat-3/source/i64_to_f128.c
+      berkeley-softfloat-3/source/i64_to_f128M.c
+      berkeley-softfloat-3/source/i64_to_f16.c
+      berkeley-softfloat-3/source/i64_to_f32.c
+      berkeley-softfloat-3/source/i64_to_f64.c
+      berkeley-softfloat-3/source/s_add128.c
+      berkeley-softfloat-3/source/s_add256M.c
+      berkeley-softfloat-3/source/s_addCarryM.c
+      berkeley-softfloat-3/source/s_addComplCarryM.c
+      berkeley-softfloat-3/source/s_addM.c
+      berkeley-softfloat-3/source/s_addMagsExtF80.c
+      berkeley-softfloat-3/source/s_addMagsF128.c
+      berkeley-softfloat-3/source/s_addMagsF16.c
+      berkeley-softfloat-3/source/s_addMagsF32.c
+      berkeley-softfloat-3/source/s_addMagsF64.c
+      berkeley-softfloat-3/source/s_approxRecip32_1.c
+      berkeley-softfloat-3/source/s_approxRecipSqrt32_1.c
+      berkeley-softfloat-3/source/s_approxRecipSqrt_1Ks.c
+      berkeley-softfloat-3/source/s_approxRecip_1Ks.c
+      berkeley-softfloat-3/source/s_compare128M.c
+      berkeley-softfloat-3/source/s_compare96M.c
+      berkeley-softfloat-3/source/s_countLeadingZeros16.c
+      berkeley-softfloat-3/source/s_countLeadingZeros32.c
+      berkeley-softfloat-3/source/s_countLeadingZeros64.c
+      berkeley-softfloat-3/source/s_countLeadingZeros8.c
+      berkeley-softfloat-3/source/s_eq128.c
+      berkeley-softfloat-3/source/s_invalidExtF80M.c
+      berkeley-softfloat-3/source/s_isNaNF128M.c
+      berkeley-softfloat-3/source/s_le128.c
+      berkeley-softfloat-3/source/s_lt128.c
+      berkeley-softfloat-3/source/s_mul128By32.c
+      berkeley-softfloat-3/source/s_mul128MTo256M.c
+      berkeley-softfloat-3/source/s_mul128To256M.c
+      berkeley-softfloat-3/source/s_mul64ByShifted32To128.c
+      berkeley-softfloat-3/source/s_mul64To128.c
+      berkeley-softfloat-3/source/s_mul64To128M.c
+      berkeley-softfloat-3/source/s_mulAddF128.c
+      berkeley-softfloat-3/source/s_mulAddF16.c
+      berkeley-softfloat-3/source/s_mulAddF32.c
+      berkeley-softfloat-3/source/s_mulAddF64.c
+      berkeley-softfloat-3/source/s_negXM.c
+      berkeley-softfloat-3/source/s_normExtF80SigM.c
+      berkeley-softfloat-3/source/s_normRoundPackToExtF80.c
+      berkeley-softfloat-3/source/s_normRoundPackToF16.c
+      berkeley-softfloat-3/source/s_normRoundPackToF32.c
+      berkeley-softfloat-3/source/s_normRoundPackToF64.c
+      berkeley-softfloat-3/source/s_normSubnormalExtF80Sig.c
+      berkeley-softfloat-3/source/s_normSubnormalF16Sig.c
+      berkeley-softfloat-3/source/s_normSubnormalF32Sig.c
+      berkeley-softfloat-3/source/s_normSubnormalF64Sig.c
+      berkeley-softfloat-3/source/s_remStepMBy32.c
+      berkeley-softfloat-3/source/s_roundMToI64.c
+      berkeley-softfloat-3/source/s_roundMToUI64.c
+      berkeley-softfloat-3/source/s_roundPackToExtF80.c
+      berkeley-softfloat-3/source/s_roundPackToF128.c
+      berkeley-softfloat-3/source/s_roundPackToF16.c
+      berkeley-softfloat-3/source/s_roundPackToF32.c
+      berkeley-softfloat-3/source/s_roundPackToF64.c
+      berkeley-softfloat-3/source/s_roundToI32.c
+      berkeley-softfloat-3/source/s_roundToI64.c
+      berkeley-softfloat-3/source/s_roundToUI32.c
+      berkeley-softfloat-3/source/s_roundToUI64.c
+      berkeley-softfloat-3/source/s_shiftRightJam128.c
+      berkeley-softfloat-3/source/s_shiftRightJam128Extra.c
+      berkeley-softfloat-3/source/s_shiftRightJam256M.c
+      berkeley-softfloat-3/source/s_shiftRightJam32.c
+      berkeley-softfloat-3/source/s_shiftRightJam64.c
+      berkeley-softfloat-3/source/s_shiftRightJam64Extra.c
+      berkeley-softfloat-3/source/s_shortShiftLeft128.c
+      berkeley-softfloat-3/source/s_shortShiftLeft64To96M.c
+      berkeley-softfloat-3/source/s_shortShiftLeftM.c
+      berkeley-softfloat-3/source/s_shortShiftRight128.c
+      berkeley-softfloat-3/source/s_shortShiftRightExtendM.c
+      berkeley-softfloat-3/source/s_shortShiftRightJam128.c
+      berkeley-softfloat-3/source/s_shortShiftRightJam128Extra.c
+      berkeley-softfloat-3/source/s_shortShiftRightJam64.c
+      berkeley-softfloat-3/source/s_shortShiftRightJam64Extra.c
+      berkeley-softfloat-3/source/s_shortShiftRightJamM.c
+      berkeley-softfloat-3/source/s_shortShiftRightM.c
+      berkeley-softfloat-3/source/s_sub128.c
+      berkeley-softfloat-3/source/s_sub1XM.c
+      berkeley-softfloat-3/source/s_sub256M.c
+      berkeley-softfloat-3/source/s_subM.c
+      berkeley-softfloat-3/source/s_subMagsExtF80.c
+      berkeley-softfloat-3/source/s_subMagsF128.c
+      berkeley-softfloat-3/source/s_subMagsF16.c
+      berkeley-softfloat-3/source/s_subMagsF32.c
+      berkeley-softfloat-3/source/s_subMagsF64.c
+      berkeley-softfloat-3/source/softfloat_state.c
+      berkeley-softfloat-3/source/ui32_to_extF80.c
+      berkeley-softfloat-3/source/ui32_to_extF80M.c
+      berkeley-softfloat-3/source/ui32_to_f128.c
+      berkeley-softfloat-3/source/ui32_to_f128M.c
+      berkeley-softfloat-3/source/ui32_to_f16.c
+      berkeley-softfloat-3/source/ui32_to_f32.c
+      berkeley-softfloat-3/source/ui32_to_f64.c
+      berkeley-softfloat-3/source/ui64_to_extF80.c
+      berkeley-softfloat-3/source/ui64_to_extF80M.c
+      berkeley-softfloat-3/source/ui64_to_f128.c
+      berkeley-softfloat-3/source/ui64_to_f128M.c
+      berkeley-softfloat-3/source/ui64_to_f16.c
+      berkeley-softfloat-3/source/ui64_to_f32.c
+      berkeley-softfloat-3/source/ui64_to_f64.c
+  else
+    extra-libraries:     softfloat1
+
+executable fpgen
+  hs-source-dirs:      test
+  main-is:             Fpgen.hs
+  ghc-options:         -threaded -Wall
+  default-language:    Haskell2010
+  build-depends:       base,
+                       softfloat-hs,
+                       parsec,
+                       directory,
+                       process
+
+executable testfloat
+  hs-source-dirs:      test
+  main-is:             Testfloat.hs
+  other-modules:       Ops
+  ghc-options:         -threaded -Wall
+  default-language:    Haskell2010
+  build-depends:       base,
+                       softfloat-hs,
+                       split,
+                       process,
+                       optparse-applicative,
+                       random

--- a/test/Testfloat.hs
+++ b/test/Testfloat.hs
@@ -111,7 +111,7 @@ main = do
   progArgs <- createArgs
   _ <- readProcess "make" [] ""
   forM_ progArgs $ \args -> do
-    testVectors <- readProcess "lib/testfloat_gen" args []
+    testVectors <- readProcess "berkeley-testfloat-3/build/Linux-x86_64-GCC/testfloat_gen" args []
     putStrLn $ "Generated test cases: " ++ show (length $ lines testVectors)
     let testCases = zip (lines testVectors) [1 ..] :: [(String, Integer)]
     forM_ testCases $ \(testData, testNumber) -> do

--- a/test/Testfloat.hs
+++ b/test/Testfloat.hs
@@ -109,7 +109,7 @@ descString =
 main :: IO ()
 main = do
   progArgs <- createArgs
-  _ <- readProcess "make" [] ""
+  _ <- readProcess "make" ["testfloat"] ""
   forM_ progArgs $ \args -> do
     testVectors <- readProcess "berkeley-testfloat-3/build/Linux-x86_64-GCC/testfloat_gen" args []
     putStrLn $ "Generated test cases: " ++ show (length $ lines testVectors)

--- a/test/Testfloat.hs
+++ b/test/Testfloat.hs
@@ -109,8 +109,8 @@ descString =
 main :: IO ()
 main = do
   progArgs <- createArgs
+  _ <- readProcess "make" [] ""
   forM_ progArgs $ \args -> do
-    print args
     testVectors <- readProcess "lib/testfloat_gen" args []
     putStrLn $ "Generated test cases: " ++ show (length $ lines testVectors)
     let testCases = zip (lines testVectors) [1 ..] :: [(String, Integer)]


### PR DESCRIPTION
This library is not packaged on most platforms. This change adds a local copy
that is built by default. There is a flag, `UseBundledC`, that can be set to
`False` to use the previous behavior of expecting a system copy of the library.

Note that the local copy is only used for Linux and Mac builds right now. There
are configurations for Windows that should be possible with testing.

This change also enables github actions to make sure that the build works across
the supported platforms.